### PR TITLE
Added autoloader check

### DIFF
--- a/app/code/local/Mashpress/Twig/Block/Template.php
+++ b/app/code/local/Mashpress/Twig/Block/Template.php
@@ -8,8 +8,12 @@ class Mashpress_Twig_Block_Template extends Mage_Core_Block_Template implements 
     protected function _construct()
     {
         parent::_construct();
-        require_once 'Twig/lib/Twig/Autoloader.php';
-		Twig_Autoloader::register();
+		
+        if (!class_exists('Twig_Loader_Filesystem')) {
+            require_once 'Twig/lib/Twig/Autoloader.php';
+		    Twig_Autoloader::register();
+        }
+		
 		$this->_loader = new Twig_Loader_Filesystem(Mage::getBaseDir('design'));
 		$this->_twig = new Twig_Environment($this->_loader);
 		$this->_twig->addExtension($this);


### PR DESCRIPTION
To avoid the second ::register() call when autoloading is already registered, e.g. in a [symfony app](https://github.com/liip/LiipMagentoBundle).
